### PR TITLE
(feat): Support use(Context)

### DIFF
--- a/examples/01_counter/src/app.tsx
+++ b/examples/01_counter/src/app.tsx
@@ -1,5 +1,7 @@
-import { Suspense, useState } from 'react';
+import { Suspense, useState, createContext } from 'react';
 import { use } from 'react18-use';
+
+const messageContext = createContext('hello world');
 
 const Counter = ({ countPromise }: { countPromise: Promise<number> }) => {
   const count = use(countPromise);
@@ -8,6 +10,7 @@ const Counter = ({ countPromise }: { countPromise: Promise<number> }) => {
 
 const App = () => {
   const [countPromise, setCountPromise] = useState(Promise.resolve(0));
+  const message = use(messageContext);
   return (
     <div>
       <button
@@ -23,6 +26,7 @@ const App = () => {
       <Suspense fallback={<p>Loading...</p>}>
         <Counter countPromise={countPromise} />
       </Suspense>
+      <p>{message} from context!</p>
     </div>
   );
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,33 +2,42 @@
 
 import ReactExports from 'react';
 
+type Usable<T> = PromiseLike<T> & {
+  status?: 'pending' | 'fulfilled' | 'rejected';
+  value?: T;
+  reason?: unknown;
+} | React.Context<T>;
+
+function isContext<T>(usable: Usable<T>): usable is React.Context<T> {
+  return '_currentValue' in usable && '$$typeof' in usable;
+}
+
 export const use =
   ReactExports.use ||
   (<T>(
-    promise: PromiseLike<T> & {
-      status?: 'pending' | 'fulfilled' | 'rejected';
-      value?: T;
-      reason?: unknown;
-    },
+    usable: Usable<T>,
   ): T => {
-    if (promise.status === 'pending') {
-      throw promise;
-    } else if (promise.status === 'fulfilled') {
-      return promise.value as T;
-    } else if (promise.status === 'rejected') {
-      throw promise.reason;
+    if (isContext(usable)) {
+      return ReactExports.useContext(usable);
+    }
+    if (usable.status === 'pending') {
+      throw usable;
+    } else if (usable.status === 'fulfilled') {
+      return usable.value as T;
+    } else if (usable.status === 'rejected') {
+      throw usable.reason;
     } else {
-      promise.status = 'pending';
-      promise.then(
+      usable.status = 'pending';
+      usable.then(
         (v) => {
-          promise.status = 'fulfilled';
-          promise.value = v;
+          usable.status = 'fulfilled';
+          usable.value = v;
         },
         (e) => {
-          promise.status = 'rejected';
-          promise.reason = e;
+          usable.status = 'rejected';
+          usable.reason = e;
         },
       );
-      throw promise;
+      throw usable;
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,13 @@
 
 import ReactExports from 'react';
 
-type Usable<T> = PromiseLike<T> & {
-  status?: 'pending' | 'fulfilled' | 'rejected';
-  value?: T;
-  reason?: unknown;
-} | React.Context<T>;
+type Usable<T> =
+  | (PromiseLike<T> & {
+      status?: 'pending' | 'fulfilled' | 'rejected';
+      value?: T;
+      reason?: unknown;
+    })
+  | React.Context<T>;
 
 function isContext<T>(usable: Usable<T>): usable is React.Context<T> {
   return '_currentValue' in usable && '$$typeof' in usable;
@@ -14,9 +16,7 @@ function isContext<T>(usable: Usable<T>): usable is React.Context<T> {
 
 export const use =
   ReactExports.use ||
-  (<T>(
-    usable: Usable<T>,
-  ): T => {
+  (<T>(usable: Usable<T>): T => {
     if (isContext(usable)) {
       return ReactExports.useContext(usable);
     }


### PR DESCRIPTION
This change adds support for `use(Context)`.

Currently, this is using what I'm calling a "manual" or naive approach to determine if the "usable" (the value passed to `use()` is a Context or a PromiseLike. As noted in #1, an alternative and maybe safer option would be to pull in `react-is` and check `usable.Consumer` and `usable.Provider` - but that means pulling in another dependency/peerDependency.

Closes: #1 